### PR TITLE
Removing backticks from bootdelegation comments

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -341,13 +341,13 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "If set with an empty string, nothing will be appended to the boot delegation system property.\n" +
             "Values to set in known environments:\n\n" +
             "Nexus:\n\n" +
-            "`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*," +
+            "`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*, " +
             "co.elastic.apm.agent.*`\n\n" +
             "Pentaho:\n\n" +
             "`boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, " +
-            "sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, " +
+            "com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, " +
             "org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, " +
-            "org.apache.xerces.dom, co.elastic.apm.agent.*`")
+            "org.apache.xerces.dom, sun.*, co.elastic.apm.agent.*`")
         .buildWithDefault("co.elastic.apm.agent.*");
 
     public boolean isActive() {

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -488,11 +488,11 @@ Values to set in known environments:
 
 Nexus:
 
-`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*`
+`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*, co.elastic.apm.agent.*`
 
 Pentaho:
 
-`boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*`
+`boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, sun.*, co.elastic.apm.agent.*`
 
 
 [options="header"]
@@ -1368,11 +1368,11 @@ The default unit for this option is `ms`
 # 
 # Nexus:
 # 
-# `boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*`
+# boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*, co.elastic.apm.agent.*
 # 
 # Pentaho:
 # 
-# `boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*`
+# boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, sun.*, co.elastic.apm.agent.*
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String

--- a/elastic-apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/elastic-apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -123,7 +123,7 @@ Valid options: <#list option.validOptionsLabelMap?values as validOption>`${valid
 # ${option.label}
 #
 </#if>
-# ${option.description?replace("\n", "\n# ", "r")}
+# ${option.description?replace("\n", "\n# ", "r")?replace("`boot_delegation_packages", "boot_delegation_packages")?replace("sun.*, co.elastic.apm.agent.*`", "sun.*, co.elastic.apm.agent.*")}
 #
 <#if option.validOptions?has_content>
 # Valid options: <#list option.validOptionsLabelMap?values as validOption>${validOption}<#if validOption_has_next>, </#if></#list>


### PR DESCRIPTION
Not elegant but does the trick...