### PR TITLE
add few other uses of covariant return types

### DIFF
--- a/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/ApacheMonitorFilterInstrumentation.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/ApacheMonitorFilterInstrumentation.java
@@ -33,6 +33,7 @@ import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
@@ -57,7 +58,7 @@ public class ApacheMonitorFilterInstrumentation extends AbstractDubboInstrumenta
             .and(takesArgument(0, named("org.apache.dubbo.rpc.Invoker")))
             .and(takesArgument(1, named("org.apache.dubbo.rpc.Invocation")))
             // makes sure we only instrument Dubbo 2.7.3+ which introduces this method
-            .and(returns(named("org.apache.dubbo.rpc.Result")
+            .and(returns(hasSuperType(named("org.apache.dubbo.rpc.Result"))
                 .and(declaresMethod(named("whenCompleteWithContext")
                     .and(takesArgument(0, named("java.util.function.BiConsumer")))))));
     }

--- a/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpClientAsyncInstrumentation.java
@@ -57,7 +57,7 @@ public class HttpClientAsyncInstrumentation extends AbstractHttpClientInstrument
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
         return named("sendAsync")
-            .and(returns(named("java.util.concurrent.CompletableFuture")))
+            .and(returns(hasSuperType(named("java.util.concurrent.CompletableFuture"))))
             .and(takesArguments(3));
     }
 

--- a/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpClientInstrumentation.java
@@ -56,7 +56,7 @@ public class HttpClientInstrumentation extends AbstractHttpClientInstrumentation
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("send").and(returns(named("java.net.http.HttpResponse")));
+        return named("send").and(returns(hasSuperType(named("java.net.http.HttpResponse"))));
     }
 
     @Nullable

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
@@ -40,6 +40,7 @@ import okhttp3.Request;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.nameEndsWith;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -108,6 +109,6 @@ public class OkHttp3ClientInstrumentation extends AbstractOkHttp3ClientInstrumen
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("execute").and(returns(named("okhttp3.Response")));
+        return named("execute").and(returns(hasSuperType(named("okhttp3.Response"))));
     }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
@@ -90,7 +90,7 @@ public abstract class AsyncInstrumentation extends AbstractServletInstrumentatio
         public ElementMatcher<? super MethodDescription> getMethodMatcher() {
             return isPublic()
                 .and(named("startAsync"))
-                .and(returns(named("javax.servlet.AsyncContext")))
+                .and(returns(hasSuperType(named("javax.servlet.AsyncContext"))))
                 .and(takesArguments(0)
                     .or(
                         takesArgument(0, named("javax.servlet.ServletRequest"))

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/RequestStreamRecordingInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/RequestStreamRecordingInstrumentation.java
@@ -61,7 +61,8 @@ public class RequestStreamRecordingInstrumentation extends AbstractServletInstru
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("getInputStream").and(returns(named("javax.servlet.ServletInputStream")));
+        return named("getInputStream")
+            .and(returns(hasSuperType(named("javax.servlet.ServletInputStream"))));
     }
 
     @Override


### PR DESCRIPTION
- searched for all usages of `returns(...)` in method matchers
- added `hasSuperType` when the return type is an `interface`, left as-is when it's a `class`.